### PR TITLE
Apply editorial theme palette with Lora/DM Sans typography

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -7,44 +7,69 @@
 body {
   @apply m-0;
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
-    "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    var(--font-sans), system-ui, -apple-system, "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-size: var(--font-size-base);
   transition: font-size 0.2s ease-out;
 }
 
+h1,
+h2,
+h3,
+h4 {
+  font-family: var(--font-serif), Georgia, "Times New Roman", serif;
+}
+
 :root {
-  --radius: 0.5rem;
-  --font-size-base: 12px;
+  --radius: 0.375rem;
+  --font-size-base: 13px;
 
-  --background: oklch(1 0 0);
-  --surface: oklch(1 0 0);
-  --muted: oklch(0.94 0.001 286.375);
-  --border: oklch(0.92 0.004 286.32);
+  /* --- Palette --- */
+  --background: oklch(0.985 0.0051 145.54);
+  --plum: oklch(0.8817 0.0077 345.37);
+  --soot: oklch(0.603 0.0133 51.2);
+  --purple-water: oklch(0.9291 0.0054 286.29);
 
-  --foreground: oklch(0.15 0.005 282); /* primary — headings, labels */
-  --secondary-foreground: oklch(0.25 0.01 282); /* secondary — body content */
-  --muted-foreground: oklch(0.45 0.01 282); /* tertiary — descriptions, hints */
-  --faded-foreground: oklch(0.65 0.01 282); /* quaternary — placeholders, disabled */
+  /* --- Surfaces --- */
+  --surface: var(--background);
+  --muted: var(--purple-water);
+  --border: oklch(0.878 0.007 286.29); /* slightly deeper purple-water */
 
-  --primary: oklch(0.646 0.196 293.756);
-  --primary-foreground: oklch(0.985 0 0);
+  /* --- Text (warm soot scale — all AA-passing against --background) ---
+     --soot L=0.603 ≈ 3.0:1 vs background — fails AA normal text.
+     Darker derivatives used for readable text; --soot kept for faded/disabled. */
+  --foreground: oklch(0.22 0.022 51.2);          /* ~13:1 — headings, labels */
+  --secondary-foreground: oklch(0.36 0.018 51.2); /* ~7:1  — body content */
+  --muted-foreground: oklch(0.49 0.015 51.2);    /* ~4.6:1 — descriptions, hints */
+  --faded-foreground: var(--soot);               /* ~3.0:1 — placeholders, disabled (AA-large) */
+
+  /* --- Primary accent (deep plum for buttons/interactive) --- */
+  --primary: oklch(0.50 0.10 345.37);
+  --primary-foreground: var(--background);
+
+  /* --- Active / "in-progress" state (plum tints) --- */
+  --active-bg: oklch(0.935 0.014 345.37);
+  --active-text: oklch(0.46 0.10 345.37);
+  --active-ring: oklch(0.82 0.028 345.37);
 }
 
 .dark {
-  --background: oklch(0.141 0.005 285.823);
-  --muted: oklch(0.274 0.006 286.033);
-  --border: oklch(0.274 0.006 286.033);
+  --background: oklch(0.16 0.008 51.2);
+  --muted: oklch(0.22 0.007 51.2);
+  --border: oklch(0.27 0.007 51.2);
 
-  --foreground: oklch(0.95 0.005 282);
-  --secondary-foreground: oklch(0.82 0.01 282);
-  --muted-foreground: oklch(0.65 0.01 282);
-  --faded-foreground: oklch(0.45 0.01 282);
+  --foreground: oklch(0.93 0.005 51.2);
+  --secondary-foreground: oklch(0.82 0.008 51.2);
+  --muted-foreground: oklch(0.67 0.010 51.2);
+  --faded-foreground: oklch(0.52 0.012 51.2);
 
-  --primary: oklch(0.71 0.176 293.756);
-  --primary-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.72 0.09 345.37);
+  --primary-foreground: oklch(0.16 0.008 51.2);
+
+  --active-bg: oklch(0.25 0.016 345.37);
+  --active-text: oklch(0.78 0.08 345.37);
+  --active-ring: oklch(0.36 0.026 345.37);
 }
 
 @theme inline {
@@ -60,8 +85,12 @@ body {
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
 
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
+  --color-active-bg: var(--active-bg);
+  --color-active-text: var(--active-text);
+  --color-active-ring: var(--active-ring);
+
+  --radius-sm: calc(var(--radius) - 3px);
+  --radius-md: calc(var(--radius) - 1px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
 }
@@ -70,7 +99,7 @@ body {
   * {
     @apply border-border cursor-default;
     scrollbar-width: thin;
-    scrollbar-color: oklch(0.65 0.01 282) transparent;
+    scrollbar-color: oklch(0.60 0.013 51.2) transparent;
   }
   body {
     @apply bg-background text-foreground;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,23 @@
 import { app } from "@/lib/config/app";
+import { DM_Sans, Lora } from "next/font/google";
 
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 
 import "./global.css";
 import { TooltipProvider } from "@/components/ui/tooltip";
+
+const serif = Lora({
+  subsets: ["latin"],
+  variable: "--font-serif",
+  display: "swap",
+});
+
+const sans = DM_Sans({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: {
@@ -47,7 +60,7 @@ export const viewport: Viewport = {
   maximumScale: 1,
   width: "device-width",
   userScalable: false,
-  themeColor: "#FFFFFF",
+  themeColor: "#f7f8f5",
 };
 
 interface Props {
@@ -55,7 +68,7 @@ interface Props {
 }
 
 const RootLayout = ({ children }: Readonly<Props>) => (
-  <html lang="en">
+  <html lang="en" className={`${serif.variable} ${sans.variable}`}>
     <body>
       <main>
         <TooltipProvider delayDuration={400} skipDelayDuration={300}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,10 +42,10 @@ const experience: Experience[] = [
 const ActiveBadge = () => (
   <Tooltip delayDuration={200}>
     <TooltipTrigger asChild>
-      <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2 py-0.5 font-medium text-emerald-500 text-xs">
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-active-bg px-2 py-0.5 font-medium text-active-text text-xs">
         <span className="relative flex h-1.5 w-1.5">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
-          <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-active-text opacity-75" />
+          <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-active-text" />
         </span>
         in progress
       </span>
@@ -70,7 +70,7 @@ const ProjectCard = ({
     <li
       className={
         isActive
-          ? "grid gap-3 rounded-lg bg-emerald-500/5 p-5 ring-1 ring-emerald-500/15 transition-colors"
+          ? "grid gap-3 rounded-lg bg-active-bg p-5 ring-1 ring-active-ring transition-colors"
           : isFeatured
             ? "grid gap-3 rounded-lg bg-primary/5 p-5"
             : "grid gap-3 rounded-lg p-5 transition-colors hover:bg-muted/50"


### PR DESCRIPTION
- Introduce four-color palette: --background, --plum, --soot, --purple-water
- Remap semantic tokens: --muted → purple-water, --border → deeper purple-water, --primary → deep plum (oklch 0.50 0.10 345.37) for interactive elements
- Derive AA-passing text scale from soot hue (--soot L=0.603 ≈ 3.0:1 vs background, fails WCAG AA normal text; darker variants used for foreground/body/muted)
- Add --active-bg/text/ring vars; replace emerald badge classes in page.tsx
- Load Lora (serif headings) and DM Sans (body) via next/font/google
- Bump base font-size 12px → 13px; tighten border-radius to 0.375rem

https://claude.ai/code/session_01QL3FM2ZQNAgUkAMsxcL76E